### PR TITLE
Filesize doesn't seem to work over ssh, fixed

### DIFF
--- a/application/libraries/Sftp.php
+++ b/application/libraries/Sftp.php
@@ -30,9 +30,11 @@ class Sftp {
 	var $port		= 22;
 	var $debug		= FALSE;
 	var $conn_sftp	= FALSE;
-    var $login_via_key = FALSE;
-    var $public_key_url = '';
-    var $private_key_url = '';
+        var $login_via_key = FALSE;
+        var $public_key_url = '';
+        var $private_key_url = '';
+        
+        var $buffer_size = 1024;
 	
 	/**
 	 * Constructor - Sets Preferences
@@ -305,7 +307,13 @@ class Sftp {
 			return FALSE;
 		}
 		
-		$contents = @fread($stream, filesize("ssh2.sftp://$sftp$rempath"));
+		$contents = null;
+		
+		while (!feof($stream)) 
+		{
+                        $contents .= @fread($stream, $this->buffer_size)
+                }
+		
 		$result = file_put_contents($locpath, $contents);
 		@fclose($stream);
 		return $result;


### PR DESCRIPTION
After using the library in a project the client reported that downloaded files are all truncated to 2kb, after some digging it seems that file_size doesn't work correctly over ssh, so I have updated the code to loop over the content of the file and then save it, the buffer size can be changed as a parameter.

Regards.
